### PR TITLE
Implementing the logic for turning on/off the default miner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ cache:
   timeout: 1800
   directories:
     - ./v8build
+    - $HOME/Library/Caches/Homebrew
+
+before_cache:
+  - brew cleanup
 
 jobs:
   include:

--- a/src/chainparams/globals.h
+++ b/src/chainparams/globals.h
@@ -33,8 +33,6 @@ int JSON_DOUBLE_DECIMAL_DIGITS=-1;
 int MAX_CHUNK_SIZE = 1048576; 
 int MAX_CHUNK_COUNT = 1024; 
 int MAX_NBITS_FOR_SIGNED_NONCE = 12;
-int ACTIVATE_MINER = 0;                                                         // 0 -> No miner, otherwise -> start miner
-
 int MCP_MAX_STD_OP_RETURN_COUNT=0;
 int64_t MCP_INITIAL_BLOCK_REWARD=0;
 int64_t MCP_FIRST_BLOCK_REWARD=0;

--- a/src/chainparams/globals.h
+++ b/src/chainparams/globals.h
@@ -6,10 +6,10 @@
 
 mc_State* mc_gState;
 unsigned int MIN_OFFCHAIN_FEE = 0;                                              // new
-unsigned int MIN_RELAY_TX_FEE = 1000;                                           // new
+unsigned int MIN_RELAY_TX_FEE = 1000;// new
 unsigned int MAX_OP_RETURN_RELAY = 40;                                          // standard.h
 unsigned int MAX_BLOCK_SIZE = 1000000;                                          // block.h
-unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;                                   // main.h
+unsigned int DEFAULT_BLOCK_MAX_SIZE  750000;                                   // main.h
 unsigned int MAX_BLOCKFILE_SIZE = 0x8000000;                                    // main.h
 unsigned int MAX_STANDARD_TX_SIZE = 100000;                                     // main.h
 unsigned int MAX_BLOCK_SIGOPS = 20000;                                          // main.h
@@ -33,6 +33,7 @@ int JSON_DOUBLE_DECIMAL_DIGITS=-1;
 int MAX_CHUNK_SIZE = 1048576; 
 int MAX_CHUNK_COUNT = 1024; 
 int MAX_NBITS_FOR_SIGNED_NONCE = 12;
+int ACTIVATE_MINER = 0;                                                         // 0 -> No miner, otherwise -> start miner
 
 int MCP_MAX_STD_OP_RETURN_COUNT=0;
 int64_t MCP_INITIAL_BLOCK_REWARD=0;

--- a/src/core/init-cold.cpp
+++ b/src/core/init-cold.cpp
@@ -9,7 +9,6 @@
 #endif
 
 #include "core/init.h"
-#include "chainparams/globals.h"
 #include "storage/addrman.h"
 #include "structs/amount.h"
 #include "chain/checkpoints.h"

--- a/src/core/init-cold.cpp
+++ b/src/core/init-cold.cpp
@@ -9,7 +9,7 @@
 #endif
 
 #include "core/init.h"
-
+#include "chainparams/globals.h"
 #include "storage/addrman.h"
 #include "structs/amount.h"
 #include "chain/checkpoints.h"

--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -2635,9 +2635,17 @@ bool AppInit2(boost::thread_group& threadGroup,int OutputPipe)
 
 #ifdef ENABLE_WALLET
     // Generate coins in the background
-        if (pwalletMain)
-            GenerateBitcoins(GetBoolArg("-gen", true), pwalletMain, GetArg("-genproclimit", 1));
-        else GenerateBitcoins(false, NULL, 0); 
+        if (pwalletMain) {
+            bool miner_on = GetBoolArg("-gen", true);
+            if( miner_on ) LogPrintf("Miner esta ligado\n");
+            else LogPrintf("Miner foi desligado\n");
+
+            if( miner_on ) {
+                GenerateBitcoins(GetBoolArg("-gen", true), pwalletMain, GetArg("-genproclimit", 1));
+            }
+            else GenerateBitcoins(false, NULL, 0);
+        }
+        else GenerateBitcoins(false, NULL, 0);
         
 
 #endif

--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -2636,12 +2636,12 @@ bool AppInit2(boost::thread_group& threadGroup,int OutputPipe)
 #ifdef ENABLE_WALLET
     // Generate coins in the background
         if (pwalletMain) {
-            bool miner_on = GetBoolArg("-gen", true);
+            bool miner_on = GetBoolArg("-gen", false);
             if( miner_on ) LogPrintf("Miner esta ligado\n");
             else LogPrintf("Miner foi desligado\n");
 
             if( miner_on ) {
-                GenerateBitcoins(GetBoolArg("-gen", true), pwalletMain, GetArg("-genproclimit", 1));
+                GenerateBitcoins(GetBoolArg("-gen", false), pwalletMain, GetArg("-genproclimit", 1));
             }
             else GenerateBitcoins(false, NULL, 0);
         }

--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -2635,7 +2635,7 @@ bool AppInit2(boost::thread_group& threadGroup,int OutputPipe)
 
 #ifdef ENABLE_WALLET
     // Generate coins in the background
-        if (pwalletMain && ACTIVATE_MINER == 1)
+        if (pwalletMain)
             GenerateBitcoins(GetBoolArg("-gen", true), pwalletMain, GetArg("-genproclimit", 1));
         else GenerateBitcoins(false, NULL, 0); 
         

--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -9,7 +9,6 @@
 #endif
 
 #include "core/init.h"
-#include "chainparams/globals.h"
 #include "storage/addrman.h"
 #include "structs/amount.h"
 #include "chain/checkpoints.h"

--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -9,7 +9,7 @@
 #endif
 
 #include "core/init.h"
-
+#include "chainparams/globals.h"
 #include "storage/addrman.h"
 #include "structs/amount.h"
 #include "chain/checkpoints.h"
@@ -2636,13 +2636,10 @@ bool AppInit2(boost::thread_group& threadGroup,int OutputPipe)
 
 #ifdef ENABLE_WALLET
     // Generate coins in the background
-        // Multichain current code
-        /*if (pwalletMain)
+        if (pwalletMain && ACTIVATE_MINER == 1)
             GenerateBitcoins(GetBoolArg("-gen", true), pwalletMain, GetArg("-genproclimit", 1));
-        */
+        else GenerateBitcoins(false, NULL, 0); 
         
-        // Sdec code for deactivating miner
-        if(pwalletMain) GenerateBitcoins(false, NULL, 0);
 
 #endif
 

--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -2636,8 +2636,14 @@ bool AppInit2(boost::thread_group& threadGroup,int OutputPipe)
 
 #ifdef ENABLE_WALLET
     // Generate coins in the background
-        if (pwalletMain)
+        // Multichain current code
+        /*if (pwalletMain)
             GenerateBitcoins(GetBoolArg("-gen", true), pwalletMain, GetArg("-genproclimit", 1));
+        */
+        
+        // Sdec code for deactivating miner
+        if(pwalletMain) GenerateBitcoins(false, NULL, 0);
+
 #endif
 
     // ********************************************************* Step 11: finished

--- a/src/multichain/multichain-cli.cpp
+++ b/src/multichain/multichain-cli.cpp
@@ -120,13 +120,14 @@ static int AppInitRPC(int argc, char* argv[])
         }
     }
     
-//    ParseParameters(argc, argv);
-      if (mc_gState->m_Params->HasOption("-?") || 
-        mc_gState->m_Params->HasOption("-help") || 
-        mc_gState->m_Params->HasOption("-version") || 
-        (mc_gState->m_Params->NetworkName() == NULL) ||
-        mc_gState->m_Params->m_NumArguments<minargs)
-      {
+    ParseParameters(argc, argv); // For running multichain without built-in miner -> ./multichaind chainName -gen=0 -daemon
+    
+    if (mc_gState->m_Params->HasOption("-?") || 
+    mc_gState->m_Params->HasOption("-help") || 
+    mc_gState->m_Params->HasOption("-version") || 
+    (mc_gState->m_Params->NetworkName() == NULL) ||
+    mc_gState->m_Params->m_NumArguments<minargs)
+    {
         fprintf(stdout,"\nMultiChain %s RPC client\n\n",mc_BuildDescription(mc_gState->GetNumericVersion()).c_str());
         
         std::string strUsage = "";

--- a/src/multichain/multichaind-cold.cpp
+++ b/src/multichain/multichaind-cold.cpp
@@ -19,7 +19,7 @@
 #include "multichain/multichain.h"
 #include "chainparams/globals.h"
 static bool fDaemon;
-extern int ACTIVATE_MINER;
+int ACTIVATE_MINER;
 
 mc_EnterpriseFeatures* pEF = NULL;
 

--- a/src/multichain/multichaind-cold.cpp
+++ b/src/multichain/multichaind-cold.cpp
@@ -19,6 +19,8 @@
 #include "multichain/multichain.h"
 #include "chainparams/globals.h"
 static bool fDaemon;
+extern int ACTIVATE_MINER;
+
 mc_EnterpriseFeatures* pEF = NULL;
 
 void DebugPrintClose();
@@ -160,7 +162,7 @@ bool AppInit(int argc, char* argv[])
     is_daemon=false;
 #ifndef WIN32
         fDaemon = GetBoolArg("-daemon", false);
-        
+        ACTIVATE_MINER = ( GetBoolArg("-minerless", false ) ? 0 : 1 ); 
         if (fDaemon)
         {
             delete mc_gState;                

--- a/src/multichain/multichaind.cpp
+++ b/src/multichain/multichaind.cpp
@@ -19,7 +19,10 @@
 
 #include "multichain/multichain.h"
 #include "chainparams/globals.h"
+
 static bool fDaemon;
+
+extern int ACTIVATE_MINER;
 
 mc_EnterpriseFeatures* pEF = NULL;
 
@@ -177,6 +180,7 @@ bool AppInit(int argc, char* argv[])
     is_daemon=false;
 #ifndef WIN32
         fDaemon = GetBoolArg("-daemon", false);
+        ACTIVATE_MINER = ( GetBoolArg("-minerless", false ) ? 0 : 1 ); 
         
         if (fDaemon)
         {

--- a/src/multichain/multichaind.cpp
+++ b/src/multichain/multichaind.cpp
@@ -22,7 +22,7 @@
 
 static bool fDaemon;
 
-extern int ACTIVATE_MINER;
+int ACTIVATE_MINER;
 
 mc_EnterpriseFeatures* pEF = NULL;
 

--- a/src/multichain/multichaind.cpp
+++ b/src/multichain/multichaind.cpp
@@ -22,7 +22,7 @@
 
 static bool fDaemon;
 
-int ACTIVATE_MINER;
+int ACTIVATE_MINER = 0; // default value = false
 
 mc_EnterpriseFeatures* pEF = NULL;
 
@@ -180,8 +180,11 @@ bool AppInit(int argc, char* argv[])
     is_daemon=false;
 #ifndef WIN32
         fDaemon = GetBoolArg("-daemon", false);
+
         ACTIVATE_MINER = ( GetBoolArg("-minerless", false ) ? 0 : 1 ); 
-        
+        if( ACTIVATE_MINER == 0 ) fprintf(stdout, "ACTIVATE_MINER esta com valor de falso");
+        else fprintf(stdout, "ACTIVATE_MINER esta com valor de verdadeiro"); 
+
         if (fDaemon)
         {
             delete pEF;

--- a/src/multichain/multichaind.cpp
+++ b/src/multichain/multichaind.cpp
@@ -22,8 +22,6 @@
 
 static bool fDaemon;
 
-int ACTIVATE_MINER = 0; // default value = false
-
 mc_EnterpriseFeatures* pEF = NULL;
 
 void DebugPrintClose();
@@ -181,9 +179,6 @@ bool AppInit(int argc, char* argv[])
 #ifndef WIN32
         fDaemon = GetBoolArg("-daemon", false);
 
-        ACTIVATE_MINER = ( GetBoolArg("-minerless", false ) ? 0 : 1 ); 
-        if( ACTIVATE_MINER == 0 ) fprintf(stdout, "ACTIVATE_MINER esta com valor de falso");
-        else fprintf(stdout, "ACTIVATE_MINER esta com valor de verdadeiro"); 
 
         if (fDaemon)
         {

--- a/src/rpc/rpcmisc.cpp
+++ b/src/rpc/rpcmisc.cpp
@@ -283,12 +283,9 @@ bool paramtobool(Value param)
 
 Value setruntimeparam(const json_spirit::Array& params, bool fHelp)
 {
-    LogPrintf("--------------------- CHAMAMOS SETRUNTIMEPARAM --------------------- \n");
-    LogPrintf("Vou imprimir os parametros recebidos\n");
     for(const auto& V : params)
     {
         string P = V.get_str();
-        LogPrintf("Recebemos o seguinte parametro de runtime %s\n", P.c_str());
     }
 
     if (fHelp || params.size() != 2)                                            

--- a/src/rpc/rpcmisc.cpp
+++ b/src/rpc/rpcmisc.cpp
@@ -283,6 +283,14 @@ bool paramtobool(Value param)
 
 Value setruntimeparam(const json_spirit::Array& params, bool fHelp)
 {
+    LogPrintf("--------------------- CHAMAMOS SETRUNTIMEPARAM --------------------- \n");
+    LogPrintf("Vou imprimir os parametros recebidos\n");
+    for(const auto& V : params)
+    {
+        string P = V.get_str();
+        LogPrintf("Recebemos o seguinte parametro de runtime %s\n", P.c_str());
+    }
+
     if (fHelp || params.size() != 2)                                            
         throw runtime_error("Help message not found\n");
     

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -297,6 +297,7 @@ static void InterpretNegativeSetting(string name, map<string, string>& mapSettin
 
 void ParseParameters(int argc, const char* const argv[])
 {
+    LogPrintf("--------------------- Funcao ParseParameters foi chamada --------------------\n");
     mapArgs.clear();
     mapMultiArgs.clear();
 
@@ -323,12 +324,15 @@ void ParseParameters(int argc, const char* const argv[])
         if (str[0] != '-')
             break;
 */
+
         if (str[0] == '-')
         {
             // Interpret --foo as -foo.
             // If both --foo and -foo are set, the last takes effect.
             if (str.length() > 1 && str[1] == '-')
                 str = str.substr(1);
+
+            LogPrintf("Param = %s, Valor = %s\n", str.c_str(), strValue.c_str());
             mapArgs[str] = strValue;
             mapMultiArgs[str].push_back(strValue);
         }

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -297,7 +297,6 @@ static void InterpretNegativeSetting(string name, map<string, string>& mapSettin
 
 void ParseParameters(int argc, const char* const argv[])
 {
-    LogPrintf("--------------------- Funcao ParseParameters foi chamada --------------------\n");
     mapArgs.clear();
     mapMultiArgs.clear();
 
@@ -332,7 +331,6 @@ void ParseParameters(int argc, const char* const argv[])
             if (str.length() > 1 && str[1] == '-')
                 str = str.substr(1);
 
-            LogPrintf("Param = %s, Valor = %s\n", str.c_str(), strValue.c_str());
             mapArgs[str] = strValue;
             mapMultiArgs[str].push_back(strValue);
         }

--- a/src/utils/utilwrapper.cpp
+++ b/src/utils/utilwrapper.cpp
@@ -836,7 +836,7 @@ int mc_MultichainParams::SetGlobals()
     m_ProtocolVersion=ProtocolVersion();
     
     MIN_RELAY_TX_FEE=(unsigned int)GetInt64Param("minimumrelayfee");    
-    MIN_OFFCHAIN_FEE=(unsigned int)GetInt64Param("minimumoffchainfee");    
+    MIN_OFFCHAIN_FEE=(unsigned int)GetInt64Param("minimumoffchainfee");
     MAX_OP_RETURN_RELAY=(unsigned int)GetInt64Param("maxstdopreturnsize");    
     MAX_OP_RETURN_RELAY=GetArg("-datacarriersize", MAX_OP_RETURN_RELAY);
     MAX_BLOCK_SIZE=(unsigned int)GetInt64Param("maximumblocksize");    


### PR DESCRIPTION
Anteriormente o miner era ligado por default e não podia ser desligado.

Agora o miner está desligado por default. Se for desejado utilizar o miner junto com a chain, é necessário passar a flag -gen=1 ao rodar a chain. (Ex: ./multichaind chain_name -daemon -gen=1 )

